### PR TITLE
Due to reordering the installation sequence to fix issue 23 we also h…

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -41,6 +41,8 @@ sudo pip install setuptools==58.2.0 # temporary fix https://github.com/mangdangr
 sudo rm -rf /var/lib/mini_pupper_bsp
 
 ### Install MangDang module
+sudo apt install -y python3-dev
+sudo git config --global --add safe.directory $BASEDIR # temporary fix https://bugs.launchpad.net/devstack/+bug/1968798
 sudo cp -r $BASEDIR/Display /var/lib/mini_pupper_bsp
 sudo PBR_VERSION=$(cd $BASEDIR; ./get-version.sh) pip install $BASEDIR/Python_Module
 
@@ -55,8 +57,6 @@ sudo sed -i "s|BASEDIR|$BASEDIR|" /etc/rc.local
 sudo sed -i "s|BASEDIR|$BASEDIR|" /usr/bin/battery_monitor
 
 ### Install LCD driver
-sudo apt install -y python3-dev
-sudo git config --global --add safe.directory $BASEDIR # temporary fix https://bugs.launchpad.net/devstack/+bug/1968798
 if [ $(lsb_release -cs) == "jammy" ]; then
     sudo sed -i "s/3-00500/3-00501/" $BASEDIR/Python_Module/MangDang/mini_pupper/nvram.py
 fi


### PR DESCRIPTION
…ave to install  python3-dev earlier. This kind of issue (dealing with low level drivers) can not be detected in a virtual environment.

## Proposed change(s)

Fixing an installation issue what was introduced with the last change. Testing in a virtual machine as limitations, this bug was not caught by virtual tests.

### Useful links (GitHub issues, forum threads, etc.)

Provide any relevant links here.

### Types of change(s)

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code refactor (non-breaking change which refactor the code)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update only
- [ ] Other (please describe)

## Testing and Verification

Please describe the tests that you ran to verify your changes. Please also provide instructions and ROS packages as appropriate so we can reproduce the test environment.

1. 1st command
2. 2nd command
3. ...

## Test Configuration

__Mini Pupper Version__  
[e.g. Simulator, Mini Pupper, Mini Pupper 2, Mini Pupper 2 Pro]

__Raspberry Pi OS + ROS version__  
[e.g. Ubuntu 22.04, ROS 2 Humble]

__PC OS + ROS version__  
[e.g. Ubuntu 22.04, ROS 2 Humble]

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/mangdangroboticsclub/mini_pupper_bsp/blob/main/CONTRIBUTING.md) guidelines.
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same change.


## Other comments

<!-- Please write here if you have any other comments. -->
<!-- Also, if you have screenshots or videos, please share them here. -->
