### PR TITLE
added missing file

### DIFF
--- a/PWMController/i2c-pwm-pca9685a.dts
+++ b/PWMController/i2c-pwm-pca9685a.dts
@@ -1,0 +1,43 @@
+/dts-v1/;
+
+/ {
+	compatible = "brcm,bcm2835";
+
+	fragment@0 {
+		target = <0xffffffff>;
+
+		__overlay__ {
+			#address-cells = <0x01>;
+			#size-cells = <0x00>;
+			clock-frequency = <0x61a80>;
+			status = "okay";
+
+			pca@40 {
+				compatible = "nxp,pca9685-pwm";
+				#pwm-cells = <0x02>;
+				reg = <0x40>;
+				status = "okay";
+				phandle = <0x01>;
+			};
+		};
+	};
+
+	__overrides__ {
+		addr = [00 00 00 01 72 65 67 3a 30 00];
+	};
+
+	__symbols__ {
+		pca = "/fragment@0/__overlay__/pca@40";
+	};
+
+	__fixups__ {
+		i2c1 = "/fragment@0:target:0";
+	};
+
+	__local_fixups__ {
+
+		__overrides__ {
+			addr = <0x00>;
+		};
+	};
+};

--- a/PWMController/install.sh
+++ b/PWMController/install.sh
@@ -3,6 +3,7 @@
 #
 
 set -x
+dtc i2c-pwm-pca9685a.dts > i2c-pwm-pca9685a.dtbo
 sudo cp i2c-pwm-pca9685a.dtbo /boot/firmware/overlays/
 make
 make install


### PR DESCRIPTION
## Proposed change(s)

This is still part of https://github.com/mangdangroboticsclub/mini_pupper_bsp/issues/28
I missed a file. Since a git repo should only contain source files compiled device trees are ignored in .gitignore
The original code had the device tree in binary format. 

### Useful links (GitHub issues, forum threads, etc.)

Provide any relevant links here.

### Types of change(s)

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code refactor (non-breaking change which refactor the code)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update only
- [ ] Other (please describe)

## Testing and Verification

Please describe the tests that you ran to verify your changes. Please also provide instructions and ROS packages as appropriate so we can reproduce the test environment.

1. 1st command
2. 2nd command
3. ...

## Test Configuration

__Mini Pupper Version__  
[e.g. Simulator, Mini Pupper, Mini Pupper 2, Mini Pupper 2 Pro]

__Raspberry Pi OS + ROS version__  
[e.g. Ubuntu 22.04, ROS 2 Humble]

__PC OS + ROS version__  
[e.g. Ubuntu 22.04, ROS 2 Humble]

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/mangdangroboticsclub/mini_pupper_bsp/blob/main/CONTRIBUTING.md) guidelines.
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same change.


## Other comments

<!-- Please write here if you have any other comments. -->
<!-- Also, if you have screenshots or videos, please share them here. -->
